### PR TITLE
KNOX-1998: WebHDFS rewrite.xml does not have rewrite rule for Location field in json

### DIFF
--- a/gateway-service-definitions/src/main/resources/services/webhdfs/2.4.0/rewrite.xml
+++ b/gateway-service-definitions/src/main/resources/services/webhdfs/2.4.0/rewrite.xml
@@ -65,6 +65,9 @@
         <content type="application/x-http-headers">
             <apply path="Location" rule="WEBHDFS/webhdfs/outbound/namenode/headers/location"/>
         </content>
+        <content type="application/json">
+            <apply path="$.Location" rule="WEBHDFS/webhdfs/outbound/namenode/headers/location"/>
+        </content>
     </filter>
 
 </rules>

--- a/gateway-service-definitions/src/main/resources/services/webhdfs/2.4.0/service.xml
+++ b/gateway-service-definitions/src/main/resources/services/webhdfs/2.4.0/service.xml
@@ -23,6 +23,7 @@
         <route path="/webhdfs/v1/**?**">
             <rewrite apply="WEBHDFS/webhdfs/inbound/namenode/file" to="request.url"/>
             <rewrite apply="WEBHDFS/webhdfs/outbound/namenode/headers" to="response.headers"/>
+            <rewrite apply="WEBHDFS/webhdfs/outbound/namenode/headers" to="response.body"/>
         </route>
         <route path="/webhdfs/v1/~?**">
             <rewrite apply="WEBHDFS/webhdfs/inbound/namenode/home" to="request.url"/>


### PR DESCRIPTION
rewrite.xml for webhdfs service definition does not have rewrite rule for Location field in json response. The location field contains a url which must be rewritten.